### PR TITLE
.gitignore fixes to only ignore the binaries in the root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,14 +58,21 @@ coverage/
 .nyc_output/
 
 # Service binaries (built from cmd/)
-checkpointor
-p2p-gateway
-fullnode
-lognode
-scorer
-walletd
-issuer
-rules-registry
+# The leading slash is to ignore just the binaries created
+# in the root directory but not something like:
+# cmd/walletd/main.go
+# cmd/walletd/server/handlers.go
+# cmd/walletd/server/server.go
+# services/walletd/Dockerfile
+/checkpointor
+/p2p-gateway
+/fullnode
+/lognode
+/scorer
+/walletd
+/issuer
+/rules-registry
+
 
 # Test coverage
 coverage.txt

--- a/cmd/walletd/main.go
+++ b/cmd/walletd/main.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/ParichayaHQ/credence/cmd/walletd/server"
+	"github.com/ParichayaHQ/credence/internal/wallet"
+)
+
+var (
+	port     = flag.String("port", "8080", "HTTP server port")
+	host     = flag.String("host", "127.0.0.1", "HTTP server host")
+	logLevel = flag.String("log-level", "info", "Log level (debug, info, warn, error)")
+	dataDir  = flag.String("data-dir", "", "Data directory for wallet storage (defaults to OS-specific location)")
+)
+
+func main() {
+	flag.Parse()
+
+	// Set up logging
+	setupLogging(*logLevel)
+
+	// Initialize wallet service
+	walletService, err := initializeWallet(*dataDir)
+	if err != nil {
+		log.Fatalf("Failed to initialize wallet: %v", err)
+	}
+
+	// Create HTTP server
+	srv := server.NewServer(walletService)
+	httpServer := &http.Server{
+		Addr:         fmt.Sprintf("%s:%s", *host, *port),
+		Handler:      srv.Router(),
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+
+	// Start server in goroutine
+	go func() {
+		log.Printf("Starting walletd HTTP server on %s:%s", *host, *port)
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("HTTP server error: %v", err)
+		}
+	}()
+
+	// Wait for shutdown signal
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit
+
+	log.Println("Shutting down walletd server...")
+
+	// Graceful shutdown with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := httpServer.Shutdown(ctx); err != nil {
+		log.Printf("Error during server shutdown: %v", err)
+	}
+
+	// Close wallet service
+	if err := walletService.Close(); err != nil {
+		log.Printf("Error closing wallet service: %v", err)
+	}
+
+	log.Println("Walletd server stopped")
+}
+
+func initializeWallet(dataDir string) (*wallet.Service, error) {
+	// Use default data directory if not specified
+	if dataDir == "" {
+		var err error
+		dataDir, err = getDefaultDataDir()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get default data directory: %w", err)
+		}
+	}
+
+	// Create data directory if it doesn't exist
+	if err := os.MkdirAll(dataDir, 0700); err != nil {
+		return nil, fmt.Errorf("failed to create data directory %s: %w", dataDir, err)
+	}
+
+	log.Printf("Using data directory: %s", dataDir)
+
+	// Initialize wallet service
+	config := &wallet.Config{
+		DataDir: dataDir,
+		// Add other configuration options as needed
+	}
+
+	walletService, err := wallet.NewService(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create wallet service: %w", err)
+	}
+
+	return walletService, nil
+}
+
+func getDefaultDataDir() (string, error) {
+	// Get user's home directory
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	// Platform-specific data directory
+	var dataDir string
+	switch {
+	case isWindows():
+		dataDir = fmt.Sprintf("%s\\AppData\\Roaming\\Credence\\wallet", homeDir)
+	case isMacOS():
+		dataDir = fmt.Sprintf("%s/Library/Application Support/Credence/wallet", homeDir)
+	default: // Linux and other Unix-like systems
+		dataDir = fmt.Sprintf("%s/.local/share/credence/wallet", homeDir)
+	}
+
+	return dataDir, nil
+}
+
+func isWindows() bool {
+	return os.Getenv("OS") == "Windows_NT"
+}
+
+func isMacOS() bool {
+	return os.Getenv("HOME") != "" && fileExists("/System/Library/CoreServices/SystemVersion.plist")
+}
+
+func fileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return err == nil
+}
+
+func setupLogging(level string) {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	
+	switch level {
+	case "debug":
+		log.SetOutput(os.Stdout)
+	case "info":
+		log.SetOutput(os.Stdout)
+	case "warn", "error":
+		log.SetOutput(os.Stderr)
+	default:
+		log.SetOutput(os.Stdout)
+	}
+
+	log.Printf("Log level set to: %s", level)
+}

--- a/cmd/walletd/server/handlers.go
+++ b/cmd/walletd/server/handlers.go
@@ -1,0 +1,502 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/ParichayaHQ/credence/internal/wallet"
+)
+
+// Health check handler
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	health := map[string]interface{}{
+		"status":    "healthy",
+		"service":   "walletd",
+		"version":   "1.0.0",
+		"timestamp": r.Context().Value("timestamp"),
+	}
+	
+	s.writeResponse(w, http.StatusOK, health, nil)
+}
+
+// Key Management Handlers
+
+type GenerateKeyRequest struct {
+	KeyType string `json:"keyType"`
+}
+
+func (s *Server) handleGenerateKey(w http.ResponseWriter, r *http.Request) {
+	var req GenerateKeyRequest
+	if err := s.parseJSON(r, &req); err != nil {
+		s.writeError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	if req.KeyType == "" {
+		s.writeError(w, http.StatusBadRequest, fmt.Errorf("keyType is required"))
+		return
+	}
+
+	key, err := s.walletService.GenerateKey(req.KeyType)
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	s.writeResponse(w, http.StatusCreated, key, nil)
+}
+
+func (s *Server) handleListKeys(w http.ResponseWriter, r *http.Request) {
+	keys, err := s.walletService.ListKeys()
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	s.writeResponse(w, http.StatusOK, keys, nil)
+}
+
+func (s *Server) handleGetKey(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	keyID := vars["keyId"]
+
+	if keyID == "" {
+		s.writeError(w, http.StatusBadRequest, fmt.Errorf("keyId is required"))
+		return
+	}
+
+	key, err := s.walletService.GetKey(keyID)
+	if err != nil {
+		if err == wallet.ErrKeyNotFound {
+			s.writeError(w, http.StatusNotFound, err)
+		} else {
+			s.writeError(w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+
+	s.writeResponse(w, http.StatusOK, key, nil)
+}
+
+func (s *Server) handleDeleteKey(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	keyID := vars["keyId"]
+
+	if keyID == "" {
+		s.writeError(w, http.StatusBadRequest, fmt.Errorf("keyId is required"))
+		return
+	}
+
+	err := s.walletService.DeleteKey(keyID)
+	if err != nil {
+		if err == wallet.ErrKeyNotFound {
+			s.writeError(w, http.StatusNotFound, err)
+		} else {
+			s.writeError(w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+
+	s.writeResponse(w, http.StatusOK, map[string]string{"message": "Key deleted successfully"}, nil)
+}
+
+// DID Management Handlers
+
+type CreateDIDRequest struct {
+	KeyID  string `json:"keyId"`
+	Method string `json:"method"`
+}
+
+func (s *Server) handleCreateDID(w http.ResponseWriter, r *http.Request) {
+	var req CreateDIDRequest
+	if err := s.parseJSON(r, &req); err != nil {
+		s.writeError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	if req.KeyID == "" || req.Method == "" {
+		s.writeError(w, http.StatusBadRequest, fmt.Errorf("keyId and method are required"))
+		return
+	}
+
+	did, err := s.walletService.CreateDID(req.KeyID, req.Method)
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	s.writeResponse(w, http.StatusCreated, did, nil)
+}
+
+func (s *Server) handleListDIDs(w http.ResponseWriter, r *http.Request) {
+	dids, err := s.walletService.ListDIDs()
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	s.writeResponse(w, http.StatusOK, dids, nil)
+}
+
+func (s *Server) handleGetDID(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	didStr := vars["did"]
+
+	if didStr == "" {
+		s.writeError(w, http.StatusBadRequest, fmt.Errorf("did is required"))
+		return
+	}
+
+	did, err := s.walletService.GetDID(didStr)
+	if err != nil {
+		if err == wallet.ErrDIDNotFound {
+			s.writeError(w, http.StatusNotFound, err)
+		} else {
+			s.writeError(w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+
+	s.writeResponse(w, http.StatusOK, did, nil)
+}
+
+type ResolveDIDRequest struct {
+	DID string `json:"did"`
+}
+
+func (s *Server) handleResolveDID(w http.ResponseWriter, r *http.Request) {
+	var req ResolveDIDRequest
+	if err := s.parseJSON(r, &req); err != nil {
+		s.writeError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	if req.DID == "" {
+		s.writeError(w, http.StatusBadRequest, fmt.Errorf("did is required"))
+		return
+	}
+
+	didDocument, err := s.walletService.ResolveDID(req.DID)
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	s.writeResponse(w, http.StatusOK, didDocument, nil)
+}
+
+// Credential Management Handlers
+
+type StoreCredentialRequest struct {
+	Credential interface{}            `json:"credential"`
+	Metadata   map[string]interface{} `json:"metadata,omitempty"`
+}
+
+func (s *Server) handleListCredentials(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case "GET":
+		// Parse query parameters for filtering
+		query := r.URL.Query()
+		filter := make(map[string]interface{})
+		
+		for key, values := range query {
+			if len(values) > 0 {
+				filter[key] = values[0]
+			}
+		}
+
+		credentials, err := s.walletService.ListCredentials(filter)
+		if err != nil {
+			s.writeError(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		s.writeResponse(w, http.StatusOK, credentials, nil)
+
+	case "POST":
+		var req StoreCredentialRequest
+		if err := s.parseJSON(r, &req); err != nil {
+			s.writeError(w, http.StatusBadRequest, err)
+			return
+		}
+
+		if req.Credential == nil {
+			s.writeError(w, http.StatusBadRequest, fmt.Errorf("credential is required"))
+			return
+		}
+
+		credentialID, err := s.walletService.StoreCredential(req.Credential, req.Metadata)
+		if err != nil {
+			s.writeError(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		response := map[string]string{"credentialId": credentialID}
+		s.writeResponse(w, http.StatusCreated, response, nil)
+	}
+}
+
+func (s *Server) handleGetCredential(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	credentialID := vars["credentialId"]
+
+	if credentialID == "" {
+		s.writeError(w, http.StatusBadRequest, fmt.Errorf("credentialId is required"))
+		return
+	}
+
+	credential, err := s.walletService.GetCredential(credentialID)
+	if err != nil {
+		if err == wallet.ErrCredentialNotFound {
+			s.writeError(w, http.StatusNotFound, err)
+		} else {
+			s.writeError(w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+
+	s.writeResponse(w, http.StatusOK, credential, nil)
+}
+
+func (s *Server) handleDeleteCredential(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	credentialID := vars["credentialId"]
+
+	if credentialID == "" {
+		s.writeError(w, http.StatusBadRequest, fmt.Errorf("credentialId is required"))
+		return
+	}
+
+	err := s.walletService.DeleteCredential(credentialID)
+	if err != nil {
+		if err == wallet.ErrCredentialNotFound {
+			s.writeError(w, http.StatusNotFound, err)
+		} else {
+			s.writeError(w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+
+	s.writeResponse(w, http.StatusOK, map[string]string{"message": "Credential deleted successfully"}, nil)
+}
+
+// Event Management Handlers
+
+type CreateEventRequest struct {
+	Type       string `json:"type"`
+	From       string `json:"from"`
+	To         string `json:"to"`
+	Context    string `json:"context"`
+	PayloadCID string `json:"payloadCID,omitempty"`
+}
+
+func (s *Server) handleListEvents(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case "GET":
+		// Parse query parameters for filtering
+		query := r.URL.Query()
+		filter := make(map[string]interface{})
+		
+		for key, values := range query {
+			if len(values) > 0 {
+				filter[key] = values[0]
+			}
+		}
+
+		events, err := s.walletService.ListEvents(filter)
+		if err != nil {
+			s.writeError(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		s.writeResponse(w, http.StatusOK, events, nil)
+
+	case "POST":
+		var req CreateEventRequest
+		if err := s.parseJSON(r, &req); err != nil {
+			s.writeError(w, http.StatusBadRequest, err)
+			return
+		}
+
+		if req.Type == "" || req.From == "" || req.To == "" || req.Context == "" {
+			s.writeError(w, http.StatusBadRequest, fmt.Errorf("type, from, to, and context are required"))
+			return
+		}
+
+		event, err := s.walletService.CreateEvent(req.Type, req.From, req.To, req.Context, req.PayloadCID)
+		if err != nil {
+			s.writeError(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		s.writeResponse(w, http.StatusCreated, event, nil)
+	}
+}
+
+func (s *Server) handleGetEvent(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	eventID := vars["eventId"]
+
+	if eventID == "" {
+		s.writeError(w, http.StatusBadRequest, fmt.Errorf("eventId is required"))
+		return
+	}
+
+	event, err := s.walletService.GetEvent(eventID)
+	if err != nil {
+		if err == wallet.ErrEventNotFound {
+			s.writeError(w, http.StatusNotFound, err)
+		} else {
+			s.writeError(w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+
+	s.writeResponse(w, http.StatusOK, event, nil)
+}
+
+// Trust Score Handlers
+
+func (s *Server) handleListTrustScores(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	did := query.Get("did")
+
+	scores, err := s.walletService.ListTrustScores(did)
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	s.writeResponse(w, http.StatusOK, scores, nil)
+}
+
+func (s *Server) handleGetTrustScore(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	didStr := vars["did"]
+	context := r.URL.Query().Get("context")
+
+	if didStr == "" {
+		s.writeError(w, http.StatusBadRequest, fmt.Errorf("did is required"))
+		return
+	}
+
+	score, err := s.walletService.GetTrustScore(didStr, context)
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	s.writeResponse(w, http.StatusOK, score, nil)
+}
+
+// Wallet Operation Handlers
+
+type LockWalletRequest struct {
+	Password string `json:"password"`
+}
+
+type UnlockWalletRequest struct {
+	Password string `json:"password"`
+}
+
+func (s *Server) handleLockWallet(w http.ResponseWriter, r *http.Request) {
+	var req LockWalletRequest
+	if err := s.parseJSON(r, &req); err != nil {
+		s.writeError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	if req.Password == "" {
+		s.writeError(w, http.StatusBadRequest, fmt.Errorf("password is required"))
+		return
+	}
+
+	err := s.walletService.Lock(req.Password)
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	s.writeResponse(w, http.StatusOK, map[string]string{"message": "Wallet locked successfully"}, nil)
+}
+
+func (s *Server) handleUnlockWallet(w http.ResponseWriter, r *http.Request) {
+	var req UnlockWalletRequest
+	if err := s.parseJSON(r, &req); err != nil {
+		s.writeError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	if req.Password == "" {
+		s.writeError(w, http.StatusBadRequest, fmt.Errorf("password is required"))
+		return
+	}
+
+	err := s.walletService.Unlock(req.Password)
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	s.writeResponse(w, http.StatusOK, map[string]string{"message": "Wallet unlocked successfully"}, nil)
+}
+
+func (s *Server) handleWalletStatus(w http.ResponseWriter, r *http.Request) {
+	status := s.walletService.GetStatus()
+	s.writeResponse(w, http.StatusOK, status, nil)
+}
+
+// Presentation Definition Handlers
+
+type EvaluatePresentationDefinitionRequest struct {
+	Definition    interface{} `json:"definition"`
+	CredentialIDs []string    `json:"credentialIds,omitempty"`
+}
+
+func (s *Server) handleEvaluatePresentationDefinition(w http.ResponseWriter, r *http.Request) {
+	var req EvaluatePresentationDefinitionRequest
+	if err := s.parseJSON(r, &req); err != nil {
+		s.writeError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	if req.Definition == nil {
+		s.writeError(w, http.StatusBadRequest, fmt.Errorf("definition is required"))
+		return
+	}
+
+	result, err := s.walletService.EvaluatePresentationDefinition(req.Definition, req.CredentialIDs)
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	s.writeResponse(w, http.StatusOK, result, nil)
+}
+
+type CreatePresentationSubmissionRequest struct {
+	Definition           interface{} `json:"definition"`
+	MatchedCredentialIDs []string    `json:"matchedCredentialIds"`
+}
+
+func (s *Server) handleCreatePresentationSubmission(w http.ResponseWriter, r *http.Request) {
+	var req CreatePresentationSubmissionRequest
+	if err := s.parseJSON(r, &req); err != nil {
+		s.writeError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	if req.Definition == nil || len(req.MatchedCredentialIDs) == 0 {
+		s.writeError(w, http.StatusBadRequest, fmt.Errorf("definition and matchedCredentialIds are required"))
+		return
+	}
+
+	submission, err := s.walletService.CreatePresentationSubmission(req.Definition, req.MatchedCredentialIDs)
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	s.writeResponse(w, http.StatusCreated, submission, nil)
+}

--- a/cmd/walletd/server/server.go
+++ b/cmd/walletd/server/server.go
@@ -1,0 +1,177 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
+	"github.com/ParichayaHQ/credence/internal/wallet"
+)
+
+// Server represents the HTTP server for the wallet service
+type Server struct {
+	walletService *wallet.Service
+	router        *mux.Router
+}
+
+// NewServer creates a new HTTP server instance
+func NewServer(walletService *wallet.Service) *Server {
+	s := &Server{
+		walletService: walletService,
+		router:        mux.NewRouter(),
+	}
+	
+	s.setupRoutes()
+	s.setupMiddleware()
+	
+	return s
+}
+
+// Router returns the configured HTTP router
+func (s *Server) Router() http.Handler {
+	return s.router
+}
+
+func (s *Server) setupRoutes() {
+	// API version prefix
+	api := s.router.PathPrefix("/v1").Subrouter()
+
+	// Health check
+	api.HandleFunc("/health", s.handleHealth).Methods("GET")
+
+	// Key management
+	keyRouter := api.PathPrefix("/keys").Subrouter()
+	keyRouter.HandleFunc("", s.handleListKeys).Methods("GET")
+	keyRouter.HandleFunc("/generate", s.handleGenerateKey).Methods("POST")
+	keyRouter.HandleFunc("/{keyId}", s.handleGetKey).Methods("GET")
+	keyRouter.HandleFunc("/{keyId}", s.handleDeleteKey).Methods("DELETE")
+
+	// DID management
+	didRouter := api.PathPrefix("/dids").Subrouter()
+	didRouter.HandleFunc("", s.handleListDIDs).Methods("GET")
+	didRouter.HandleFunc("/create", s.handleCreateDID).Methods("POST")
+	didRouter.HandleFunc("/resolve", s.handleResolveDID).Methods("POST")
+	didRouter.HandleFunc("/{did:.*}", s.handleGetDID).Methods("GET")
+
+	// Credential management
+	credRouter := api.PathPrefix("/credentials").Subrouter()
+	credRouter.HandleFunc("", s.handleListCredentials).Methods("GET", "POST")
+	credRouter.HandleFunc("/{credentialId}", s.handleGetCredential).Methods("GET")
+	credRouter.HandleFunc("/{credentialId}", s.handleDeleteCredential).Methods("DELETE")
+
+	// Event management (vouches/reports)
+	eventRouter := api.PathPrefix("/events").Subrouter()
+	eventRouter.HandleFunc("", s.handleListEvents).Methods("GET", "POST")
+	eventRouter.HandleFunc("/{eventId}", s.handleGetEvent).Methods("GET")
+
+	// Trust scores
+	scoreRouter := api.PathPrefix("/scores").Subrouter()
+	scoreRouter.HandleFunc("", s.handleListTrustScores).Methods("GET")
+	scoreRouter.HandleFunc("/{did:.*}", s.handleGetTrustScore).Methods("GET")
+
+	// Presentation definitions
+	presDefRouter := api.PathPrefix("/presentation-definitions").Subrouter()
+	presDefRouter.HandleFunc("/evaluate", s.handleEvaluatePresentationDefinition).Methods("POST")
+	presDefRouter.HandleFunc("/submissions", s.handleCreatePresentationSubmission).Methods("POST")
+
+	// Wallet operations
+	walletRouter := api.PathPrefix("/wallet").Subrouter()
+	walletRouter.HandleFunc("/lock", s.handleLockWallet).Methods("POST")
+	walletRouter.HandleFunc("/unlock", s.handleUnlockWallet).Methods("POST")
+	walletRouter.HandleFunc("/status", s.handleWalletStatus).Methods("GET")
+}
+
+func (s *Server) setupMiddleware() {
+	// CORS middleware
+	corsHandler := handlers.CORS(
+		handlers.AllowedOrigins([]string{"http://localhost:*", "https://localhost:*"}),
+		handlers.AllowedMethods([]string{"GET", "POST", "PUT", "DELETE", "OPTIONS"}),
+		handlers.AllowedHeaders([]string{"Content-Type", "Authorization", "X-Requested-With"}),
+		handlers.AllowCredentials(),
+	)
+
+	// Apply CORS to all routes
+	s.router.Use(corsHandler)
+
+	// Request logging middleware
+	s.router.Use(s.loggingMiddleware)
+
+	// Error handling middleware
+	s.router.Use(s.errorHandlingMiddleware)
+
+	// Content type middleware
+	s.router.Use(s.contentTypeMiddleware)
+}
+
+func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
+	return handlers.LoggingHandler(os.Stdout, next)
+}
+
+func (s *Server) errorHandlingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if err := recover(); err != nil {
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) contentTypeMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		next.ServeHTTP(w, r)
+	})
+}
+
+// Response represents a standard API response
+type Response struct {
+	Success   bool        `json:"success"`
+	Data      interface{} `json:"data,omitempty"`
+	Error     string      `json:"error,omitempty"`
+	Timestamp time.Time   `json:"timestamp"`
+}
+
+// writeResponse writes a JSON response
+func (s *Server) writeResponse(w http.ResponseWriter, statusCode int, data interface{}, err error) {
+	resp := Response{
+		Success:   err == nil,
+		Data:      data,
+		Timestamp: time.Now(),
+	}
+
+	if err != nil {
+		resp.Error = err.Error()
+	}
+
+	w.WriteHeader(statusCode)
+	if encodeErr := json.NewEncoder(w).Encode(resp); encodeErr != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+// writeError writes an error response
+func (s *Server) writeError(w http.ResponseWriter, statusCode int, err error) {
+	s.writeResponse(w, statusCode, nil, err)
+}
+
+// parseJSON parses JSON request body
+func (s *Server) parseJSON(r *http.Request, v interface{}) error {
+	if r.Header.Get("Content-Type") != "application/json" {
+		return fmt.Errorf("content-type must be application/json")
+	}
+
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	
+	if err := decoder.Decode(v); err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	return nil
+}

--- a/services/checkpointor/Dockerfile
+++ b/services/checkpointor/Dockerfile
@@ -1,0 +1,56 @@
+# Multi-stage build for checkpointor service
+FROM golang:1.24.1-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache git make build-base
+
+# Set working directory
+WORKDIR /app
+
+# Copy go mod files first (for better caching)
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the checkpointor binary
+RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -o /app/bin/checkpointor ./cmd/checkpointor
+
+# Final stage - minimal runtime image
+FROM alpine:latest
+
+# Install runtime dependencies
+RUN apk --no-cache add ca-certificates tzdata
+
+# Create non-root user
+RUN addgroup -g 1001 -S credence && \
+    adduser -u 1001 -S credence -G credence
+
+# Create directories
+RUN mkdir -p /data /config && \
+    chown -R credence:credence /data /config
+
+# Copy binary from builder stage
+COPY --from=builder /app/bin/checkpointor /usr/local/bin/checkpointor
+
+# Switch to non-root user
+USER credence
+
+# Expose ports
+EXPOSE 8085
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8085/health || exit 1
+
+# Set default environment variables
+ENV LOG_LEVEL=info \
+    API_PORT=8085 \
+    DATA_DIR=/data \
+    CONFIG_PATH=/config/checkpointor.yml \
+    BLS_PRIVATE_KEY_PATH=/config/keys/bls.key \
+    COMMITTEE_SELECTION_VRF=true
+
+# Default command
+CMD ["checkpointor"]

--- a/services/fullnode/Dockerfile
+++ b/services/fullnode/Dockerfile
@@ -1,0 +1,56 @@
+# Multi-stage build for fullnode service
+FROM golang:1.24.1-alpine AS builder
+
+# Install build dependencies  
+RUN apk add --no-cache git make build-base
+
+# Set working directory
+WORKDIR /app
+
+# Copy go mod files first (for better caching)
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the fullnode binary with SQLite support (no RocksDB)
+RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -o /app/bin/fullnode ./cmd/fullnode
+
+# Final stage - minimal runtime image
+FROM alpine:latest
+
+# Install runtime dependencies
+RUN apk --no-cache add ca-certificates tzdata
+
+# Create non-root user
+RUN addgroup -g 1001 -S credence && \
+    adduser -u 1001 -S credence -G credence
+
+# Create directories
+RUN mkdir -p /data /config /shared-data && \
+    chown -R credence:credence /data /config /shared-data
+
+# Copy binary from builder stage
+COPY --from=builder /app/bin/fullnode /usr/local/bin/fullnode
+
+# Switch to non-root user
+USER credence
+
+# Expose ports
+EXPOSE 8081
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8081/health || exit 1
+
+# Set default environment variables
+ENV LOG_LEVEL=info \
+    API_PORT=8081 \
+    DATA_DIR=/data \
+    CONFIG_PATH=/config/fullnode.yml \
+    MODE=full \
+    P2P_ENDPOINT=http://p2p-gateway:8080
+
+# Default command
+CMD ["fullnode"]

--- a/services/lognode/Dockerfile
+++ b/services/lognode/Dockerfile
@@ -1,0 +1,57 @@
+# Multi-stage build for lognode service (Trillian personality)
+FROM golang:1.24.1-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache git make build-base
+
+# Set working directory
+WORKDIR /app
+
+# Copy go mod files first (for better caching)
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the lognode binary
+RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -o /app/bin/lognode ./cmd/lognode
+
+# Final stage - minimal runtime image
+FROM alpine:latest
+
+# Install runtime dependencies
+RUN apk --no-cache add ca-certificates tzdata postgresql-client
+
+# Create non-root user
+RUN addgroup -g 1001 -S credence && \
+    adduser -u 1001 -S credence -G credence
+
+# Create directories
+RUN mkdir -p /data /config && \
+    chown -R credence:credence /data /config
+
+# Copy binary from builder stage
+COPY --from=builder /app/bin/lognode /usr/local/bin/lognode
+
+# Switch to non-root user
+USER credence
+
+# Expose ports
+EXPOSE 8083
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8083/health || exit 1
+
+# Set default environment variables
+ENV LOG_LEVEL=info \
+    API_PORT=8083 \
+    DATA_DIR=/data \
+    CONFIG_PATH=/config/lognode.yml \
+    DATABASE_URL=postgres://credence:password@postgres/trillian \
+    TREE_TYPE=merkle \
+    SIGNING_FREQUENCY=1m
+
+# Default command
+CMD ["lognode"]

--- a/services/p2p-gateway/Dockerfile
+++ b/services/p2p-gateway/Dockerfile
@@ -1,0 +1,55 @@
+# Multi-stage build for p2p-gateway service
+FROM golang:1.24.1-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache git make build-base
+
+# Set working directory
+WORKDIR /app
+
+# Copy go mod files first (for better caching)
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the p2p-gateway binary
+RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -o /app/bin/p2p-gateway ./cmd/p2p-gateway
+
+# Final stage - minimal runtime image
+FROM alpine:latest
+
+# Install runtime dependencies
+RUN apk --no-cache add ca-certificates tzdata
+
+# Create non-root user
+RUN addgroup -g 1001 -S credence && \
+    adduser -u 1001 -S credence -G credence
+
+# Create directories
+RUN mkdir -p /data /config && \
+    chown -R credence:credence /data /config
+
+# Copy binary from builder stage
+COPY --from=builder /app/bin/p2p-gateway /usr/local/bin/p2p-gateway
+
+# Switch to non-root user
+USER credence
+
+# Expose ports
+EXPOSE 4001 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+
+# Set default environment variables
+ENV LOG_LEVEL=info \
+    P2P_PORT=4001 \
+    API_PORT=8080 \
+    DATA_DIR=/data \
+    CONFIG_PATH=/config/p2p-gateway.yml
+
+# Default command
+CMD ["p2p-gateway"]

--- a/services/scorer/Dockerfile
+++ b/services/scorer/Dockerfile
@@ -1,0 +1,58 @@
+# Multi-stage build for scorer service
+FROM golang:1.24.1-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache git make build-base
+
+# Set working directory
+WORKDIR /app
+
+# Copy go mod files first (for better caching)
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the scorer binary
+RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -o /app/bin/scorer ./cmd/scorer
+
+# Final stage - minimal runtime image
+FROM alpine:latest
+
+# Install runtime dependencies
+RUN apk --no-cache add ca-certificates tzdata
+
+# Create non-root user
+RUN addgroup -g 1001 -S credence && \
+    adduser -u 1001 -S credence -G credence
+
+# Create directories
+RUN mkdir -p /data /config && \
+    chown -R credence:credence /data /config
+
+# Copy binary from builder stage
+COPY --from=builder /app/bin/scorer /usr/local/bin/scorer
+
+# Switch to non-root user
+USER credence
+
+# Expose ports
+EXPOSE 8082
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8082/health || exit 1
+
+# Set default environment variables
+ENV LOG_LEVEL=info \
+    API_PORT=8082 \
+    DATA_DIR=/data \
+    CONFIG_PATH=/config/scorer.yml \
+    REDIS_URL=redis://redis:6379 \
+    ALGORITHM_VERSION=v2.1 \
+    UPDATE_INTERVAL=5m \
+    MAX_GRAPH_DEPTH=6
+
+# Default command
+CMD ["scorer"]

--- a/services/walletd/Dockerfile
+++ b/services/walletd/Dockerfile
@@ -1,0 +1,56 @@
+# Multi-stage build for walletd service
+FROM golang:1.24.1-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache git make build-base
+
+# Set working directory
+WORKDIR /app
+
+# Copy go mod files first (for better caching)
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the walletd binary
+RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -o /app/bin/walletd ./cmd/walletd
+
+# Final stage - minimal runtime image
+FROM alpine:latest
+
+# Install runtime dependencies
+RUN apk --no-cache add ca-certificates tzdata
+
+# Create non-root user
+RUN addgroup -g 1001 -S credence && \
+    adduser -u 1001 -S credence -G credence
+
+# Create directories
+RUN mkdir -p /data /config && \
+    chown -R credence:credence /data /config
+
+# Copy binary from builder stage
+COPY --from=builder /app/bin/walletd /usr/local/bin/walletd
+
+# Switch to non-root user
+USER credence
+
+# Expose ports
+EXPOSE 8084
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8084/health || exit 1
+
+# Set default environment variables
+ENV LOG_LEVEL=info \
+    API_PORT=8084 \
+    DATA_DIR=/data \
+    CONFIG_PATH=/config/walletd.yml \
+    STORAGE_TYPE=sqlite \
+    KEY_DERIVATION=Ed25519
+
+# Default command
+CMD ["walletd"]


### PR DESCRIPTION
The `.gitignore` entries meant to ignore the binaries that were being created in the root directory. However, it was ignoring even the other files.

E.g., the entry for `walletd` was also ignoring the below files:
```
cmd/walletd/main.go
cmd/walletd/server/handlers.go
cmd/walletd/server/server.go
services/walletd/Dockerfile
```